### PR TITLE
Add basic E2E tests

### DIFF
--- a/.cypress/e2e/home.cy.js
+++ b/.cypress/e2e/home.cy.js
@@ -1,33 +1,10 @@
 const { describeName } = require("../utils/test.utils");
 
 const url = "/";
-const pages = ["About", "Resume", "Musings", "Canvas"];
-const links = ["LinkedIn", "Instagram", "Twitter"];
+const pages = ["gRPC"];
+const links = ["Grafana", "Jaeger", "Prometheus"];
 
 Cypress.env().viewportSizes.forEach((viewportSize) => {
-  describe(
-    describeName(Cypress, viewportSize, "Themes from localStorage"),
-    () => {
-      const commonActions = () => {
-        cy.viewport(...viewportSize);
-        cy.visit(url);
-        cy.wait(30000);
-        cy.screenshot();
-      };
-
-      it("Should render light theme background as expected", () => {
-        commonActions();
-        cy.get("html").should("not.have.class", "dark");
-      });
-
-      it("Should render light theme background as expected", () => {
-        window.localStorage.setItem("theme", "dark");
-        commonActions();
-        cy.get("html").should("have.class", "dark");
-      });
-    }
-  );
-
   describe(describeName(Cypress, viewportSize, "navigation"), () => {
     beforeEach(() => {
       cy.viewport(...viewportSize);
@@ -36,7 +13,7 @@ Cypress.env().viewportSizes.forEach((viewportSize) => {
 
     it("Should contain expected links", () => {
       cy.screenshot();
-      [...pages, ...links, "Theme"].forEach((link) => {
+      [...pages, ...links].forEach((link) => {
         cy.contains(link);
       });
     });
@@ -44,7 +21,7 @@ Cypress.env().viewportSizes.forEach((viewportSize) => {
     pages.forEach((page) => {
       it(`Should navigate to ${page} page`, () => {
         cy.contains(page).click();
-        cy.wait(2000);
+        cy.wait(5000);
         cy.screenshot();
       });
     });

--- a/.cypress/utils/test.utils.js
+++ b/.cypress/utils/test.utils.js
@@ -1,3 +1,5 @@
+require("dotenv").config();
+
 function describeName(Cypress, viewportSize, groupDefinition) {
   const groupString = groupDefinition ? ` - ${groupDefinition}` : "";
   return `${Cypress.browser.name} @ ${viewportSize.join("x")}${groupString}`;

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+{
+  "name": "e2e.nextjs-grpc.projects.utkusarioglu.com",
+  "dockerComposeFile": [
+    "../.docker/docker-compose.dev.yml",
+    "docker-compose.yml"
+  ],
+  "service": "nextjs-grpc-e2e",
+  "workspaceFolder": "/utkusarioglu-com/projects/nextjs-grpc/e2e",
+  "postCreateCommand": "scripts/post-create-command.sh",
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "workbench.colorCustomizations": {
+          "activityBar.background": "#223453"
+        }
+      }
+    }
+  }
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "3.9"
+services:
+  nextjs-grpc-e2e:
+    command: /bin/sh -c "while sleep 1000; do :; done"
+    volumes:
+      - type: volume
+        source: vscode-extensions
+        target: /root/.vscode-server/extensions
+      - type: volume
+        source: vscode-extensions-insiders
+        target: /root/.vscode-server-insiders/extensions
+      - type: bind
+        source: ~/.config/gh
+        target: /home/hardhat/.config/gh
+        read_only: true
+
+volumes:
+  vscode-extensions:
+    name: nextjs-grpc-e2e-vscode-extensions
+  vscode-extensions-insiders:
+    name: nextjs-grpc-e2e-vscode-extensions-insiders

--- a/.docker/docker-compose.dev.yml
+++ b/.docker/docker-compose.dev.yml
@@ -1,0 +1,9 @@
+version: "3.9"
+
+services:
+  nextjs-grpc-e2e:
+    image: utkusarioglu/node-devcontainer:17-slim.0.1
+    volumes:
+      - type: bind
+        source: ..
+        target: /utkusarioglu-com/projects/nextjs-grpc/e2e

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,9 +1,12 @@
+require("dotenv").config();
 const { defineConfig } = require("cypress");
+
+const baseUrl = `https://${process.env.BASE_URL}`;
 
 module.exports = defineConfig({
   e2e: {
     supportFile: false,
-    baseUrl: "https://target-http-server",
+    baseUrl,
     setupNodeEvents(on, config) {
       const windowSize = config.env.windowSize;
       on("before:browser:launch", (browser = {}, launchOptions) => {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "devDependencies": {
-    "cypress": "^10.3.1"
+    "cypress": "^10.3.1",
+    "dotenv": "^16.0.3"
   }
 }

--- a/scripts/docker-run-cypress.sh
+++ b/scripts/docker-run-cypress.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-source .env
-WORKDIR=/utkusarioglu/projects/nextjs-grpc/e2e
+WORKDIR=/utkusarioglu-com/projects/nextjs-grpc/e2e
+source "$WORKDIR/.env"
+repo_dir="$GITHUB_WORKSPACE/e2e"
 
 if [ ! -f $(/var/run/docker.sock) ];
 then
@@ -13,12 +14,14 @@ fi
 docker run \
   --rm \
   -t \
-  -v $(pwd)/.cypress:$WORKDIR/cypress \
-  -v $(pwd)/scripts:$WORKDIR/scripts \
-  -v $(pwd)/cypress.config.js:$WORKDIR/cypress.config.js \
+  -v "$repo_dir/.env:$WORKDIR/.env" \
+  -v "$repo_dir/.cypress:$WORKDIR/cypress" \
+  -v "$repo_dir/scripts:$WORKDIR/scripts" \
+  -v "$repo_dir/cypress.config.js:$WORKDIR/cypress.config.js" \
+  -v "$repo_dir/package.json:$WORKDIR/package.json" \
   -w $WORKDIR \
-  --env-file $(pwd)/.env \
+  --network host \
   --name nextjs-grpc-e2e \
-  --add-host target-http-server:host-gateway \
-  --entrypoint scripts/run-cypress-tests.js \
-  cypress/included:10.0.0 
+  --add-host "$BASE_URL:127.0.0.1" \
+  --entrypoint scripts/run-cypress-tests.sh \
+  cypress/included:10.0.0 \

--- a/scripts/post-create-command.sh
+++ b/scripts/post-create-command.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "No registered post-create comands"

--- a/scripts/run-cypress-tests.sh
+++ b/scripts/run-cypress-tests.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+LOGS_PATH=".cypress/artifacts/logs"
+YARN_LOGS_PATH=$LOGS_PATH/yarn.log
+
+mkdir -p $LOGS_PATH
+touch $YARN_LOGS_PATH
+
+yarn > $YARN_LOGS_PATH
+
+scripts/run-cypress-tests.js


### PR DESCRIPTION
Closes #1 by implementing very basic E2E testing for the project.
This PR still leaves a lot of functionality untested but it's a start.

Most of the logic is migrated from `utkusarioglu/utkusarioglu-com`.
