### PR TITLE
Chore: Update cypress version refactor install

### DIFF
--- a/.cypress/e2e/login.cy.js
+++ b/.cypress/e2e/login.cy.js
@@ -29,7 +29,7 @@ Cypress.env().viewportSizes.forEach((viewportSize) => {
           cy.get("#password").click().type(keyword);
           cy.get("button[type=submit]").click();
           cy.contains(message);
-          cy.wait(2e3);
+          cy.wait(10e3);
           cy.screenshot(`after "${keyword}" submit`);
         });
       });

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,6 +1,7 @@
 require("dotenv").config();
 const { defineConfig } = require("cypress");
 
+// const baseUrl = `https://${process.env.BASE_URL}`;
 const baseUrl = `https://${process.env.BASE_URL}`;
 
 module.exports = defineConfig({

--- a/scripts/docker-run-cypress.sh
+++ b/scripts/docker-run-cypress.sh
@@ -2,7 +2,8 @@
 
 # WORKDIR=/utkusarioglu-com/projects/nextjs-grpc/e2e
 WORKDIR=/cypress-workspace
-CYPRESS_VERSION=12.13.0
+# CYPRESS_VERSION=12.13.0
+CYPRESS_VERSION=12.17.2
 
 if [ -z "$CI" ]; then
   GITHUB_WORKSPACE=$(pwd)/..
@@ -18,14 +19,12 @@ fi
 repo_dir="$GITHUB_WORKSPACE/e2e"
 source "$repo_dir/.env"
 
-if [ ! -f $(/var/run/docker.sock) ];
+if [ "$(id -u)" != "0" ] && [ ! -f $(/var/run/docker.sock) ];
 then
   echo "This script requires docker to be available in the environment"
   echo "If you are inside the devcontainer, try running the script from the host."
   exit 1
 fi
-
-echo "Using cypress/included:$CYPRESS_VERSION…"
 
 docker run \
   --rm \
@@ -46,4 +45,6 @@ docker run \
   --name nextjs-grpc-e2e \
   --add-host "$BASE_URL:127.0.0.1" \
   --entrypoint scripts/run-cypress-tests.sh \
-  cypress/included:$CYPRESS_VERSION \
+  cypress/included:$CYPRESS_VERSION
+
+  # --privileged \

--- a/scripts/prep-cypress-tests.sh
+++ b/scripts/prep-cypress-tests.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+LOGS_PATH=".cypress/artifacts/logs"
+YARN_LOGS_PATH=$LOGS_PATH/yarn.log
+
+mkdir -p $LOGS_PATH
+touch $YARN_LOGS_PATH
+
+yarn --frozen-lockfile
+
+mkdir cypress/artifacts

--- a/scripts/run-cypress-tests.sh
+++ b/scripts/run-cypress-tests.sh
@@ -1,11 +1,16 @@
 #!/bin/bash
 
-LOGS_PATH=".cypress/artifacts/logs"
-YARN_LOGS_PATH=$LOGS_PATH/yarn.log
+#
+# scripts/prep-cypress-tests.sh needs to be run before this script
+#
+CA_PATH=/utkusarioglu-com/projects/nextjs-grpc/e2e/.certs/intermediate/ca.crt
 
-mkdir -p $LOGS_PATH
-touch $YARN_LOGS_PATH
+echo '<Certificate>'
+cat $CA_PATH
+echo '</ Certificate>'
 
-yarn --frozen-lockfile
+NODE_EXTRA_CA_CERTS=$CA_PATH scripts/run-cypress-tests.js
 
-scripts/run-cypress-tests.js
+echo '<artifacts folder>'
+ls -al /utkusarioglu-com/projects/nextjs-grpc/e2e/cypress/artifacts
+echo '</ artifacts folder>'


### PR DESCRIPTION
- Split cypress test runner and installation commands into separate
  shell files.
- Update cypress version. However the shell file that runs docker for
  cypress doesnt' actually have any part in e2e tests. This file should
  be removed once a docker compose file that does the same task is
  introduced.
- Increase the timeout duration in tests. This is done because the CI
  runner is resource starved and it takes forever for the pages to be
  rendered.
